### PR TITLE
README: disables goreportcard due to gojp/goreportcard/issues/90

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![GoDoc](https://godoc.org/github.com/osrg/namazu/nmz?status.svg)](https://godoc.org/github.com/osrg/namazu/nmz)
 [![Build Status](https://travis-ci.org/osrg/namazu.svg?branch=master)](https://travis-ci.org/osrg/namazu)
 [![Coverage Status](https://coveralls.io/repos/github/osrg/namazu/badge.svg?branch=master)](https://coveralls.io/github/osrg/namazu?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/osrg/namazu)](https://goreportcard.com/report/github.com/osrg/namazu)
 
 Namazu (formerly named Earthquake) is a programmable fuzzy scheduler for testing real implementations of distributed system such as ZooKeeper.
 


### PR DESCRIPTION
It doesn't work after renaming `osrg/earthquake` to `osrg/namazu`.
We will re-enable it when it works again.

https://github.com/gojp/goreportcard/issues/90