### PR TITLE
cli: add a new option -cmd option for executing given command to proc…

### DIFF
--- a/nmz/container/proc.go
+++ b/nmz/container/proc.go
@@ -30,7 +30,7 @@ func ServeProcInspector(c *docker.Container, watchInterval time.Duration) error 
 		RootPID:         c.State.Pid,
 		WatchInterval:   watchInterval,
 	}
-	insp.Serve()
+	insp.Serve(nil)
 	// NOTREACHED
 	return nil
 }

--- a/nmz/inspector/proc/proc.go
+++ b/nmz/inspector/proc/proc.go
@@ -49,7 +49,7 @@ func NewProcInspector(orchestratorURL, entityID string, rootPID int, watchInterv
 	}, nil
 }
 
-func (this *ProcInspector) Serve() error {
+func (this *ProcInspector) Serve(endCh <-chan struct{}) error {
 	log.Debugf("Initializing Process Inspector %#v", this)
 	var err error
 
@@ -74,6 +74,9 @@ func (this *ProcInspector) Serve() error {
 			}
 		case <-this.stopCh:
 			log.Info("Shutting down..")
+			return nil
+		case <-endCh:
+			log.Infof("Shutting down (via end channel)..")
 			return nil
 		}
 	}

--- a/nmz/inspector/proc/proc_test.go
+++ b/nmz/inspector/proc/proc_test.go
@@ -45,7 +45,7 @@ func TestProcInspector(t *testing.T) {
 	insp, err := NewProcInspector("local://", "dummy", pid, 200*time.Millisecond)
 	assert.NoError(t, err)
 	go func() {
-		insp.Serve()
+		insp.Serve(nil)
 	}()
 	defer insp.Shutdown()
 	// dummy test at the moment


### PR DESCRIPTION
…ess inspector

This commit adds a new option -cmd to process inspector. With this
option, we don't need to start execution of target before
inspection. Below is an example:
$ sudo nmz inspectors proc -watch-interval 100ms -autopilot\
 dirichlet.toml  -cmd "./integration.test -test.v -test.run TestIssue2746\$ -test.count 1000"