### PR TITLE
fs inspector support for namazu container

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ explorePolicy = "random"
   # Default: true
   enableProcInspector = true
   procWatchInterval = "1s"
+  # Default: true (for volumes (`-v /foo:/bar`))
+  enableFSInspector = true
 ```
 For other parameters, please refer to [`config.go`](nmz/util/config/config.go) and [`randompolicy.go`](nmz/explorepolicy/random/randompolicy.go).
 

--- a/nmz/cli/container/run/run.go
+++ b/nmz/cli/container/run/run.go
@@ -89,6 +89,11 @@ func Run(args []string) int {
 		return 1
 	}
 
+	dockerOpt, err = container.StartNamazuRoutinesPre(dockerOpt, nmzCfg)
+	if err != nil {
+		panic(log.Critical(err))
+	}
+
 	client, err := ns.NewDockerClient()
 	if err != nil {
 		panic(log.Critical(err))
@@ -113,7 +118,7 @@ func Run(args []string) int {
 		log.Info("Namazu container is running the container in background, but Namazu itself keeps running in foreground.")
 	}
 
-	err = container.StartNamazuRoutines(c, nmzCfg)
+	err = container.StartNamazuRoutinesPost(c, nmzCfg)
 	if err != nil {
 		panic(log.Critical(err))
 	}

--- a/nmz/container/fs.go
+++ b/nmz/container/fs.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"github.com/osrg/hookfs/hookfs"
+	"github.com/osrg/namazu/nmz/inspector/fs"
+	ocutil "github.com/osrg/namazu/nmz/util/orchestrator"
+)
+
+func ServeFSInspector(orig, mountpoint string) error {
+	hook := fs.FilesystemInspector{
+		OrchestratorURL: ocutil.LocalOrchestratorURL,
+		EntityID:        "_namazu_container_fs_inspector_" + orig,
+	}
+	fs, err := hookfs.NewHookFs(orig, mountpoint, &hook)
+	if err != nil {
+		return err
+	}
+	if err = fs.Serve(); err != nil {
+		return err
+	}
+	// NOTREACHED
+	return nil
+}

--- a/nmz/util/config/config.go
+++ b/nmz/util/config/config.go
@@ -90,6 +90,7 @@ func New() Config {
 	cfg.SetDefault("container", map[string]interface{}{
 		"enableEthernetInspector": false,
 		"enableProcInspector":     true,
+		"enableFSInspector":       true,
 		"ethernetNFQNumber":       42,
 		"procWatchInterval":       time.Second,
 	})


### PR DESCRIPTION
Fix #161


PTAL @v01dstar 

How to test:
```
$ cat > /tmp/container.toml << EOF
explorePolicy = "random"
[explorePolicyParam]
  maxInterval = "3000ms"
  faultActionProbability = 0.5

[container]
  enableProcInspector = false
  enableFSInspector = true
EOF
$ docker pull alpine
$ mkdir /tmp/foo && echo something > /tmp/foo/bar
$ sudo ./bin/nmz container run -it --rm -v /tmp/foo:/foo --nmz-autopilot /tmp/container.toml alpine sh
container# ls /foo (sometimes slow, sometimes EIO)
```