### PR TITLE
cli:fix ethernet inspector cannot init commonFlags

### DIFF
--- a/nmz/cli/inspectors/ethernet.go
+++ b/nmz/cli/inspectors/ethernet.go
@@ -77,7 +77,7 @@ func (cmd etherCmd) Run(args []string) int {
 		return 1
 	}
 
-	autopilot, err := conditionalStartAutopilotOrchestrator(_fsFlags.commonFlags)
+	autopilot, err := conditionalStartAutopilotOrchestrator(_etherFlags.commonFlags)
 	if err != nil {
 		log.Critical(err)
 		return 1


### PR DESCRIPTION
ethernet inspector cannot init commonFlags  