### PR TITLE
cli: not print zmq addr in netfilter mode

### DIFF
--- a/nmz/cli/inspectors/ethernet.go
+++ b/nmz/cli/inspectors/ethernet.go
@@ -94,7 +94,7 @@ func (cmd etherCmd) Run(args []string) int {
 			EnableTCPWatcher:  true,
 		}
 	} else {
-		log.Infof("Using NFQ %s", _etherFlags.HookSwitchZMQAddr)
+		log.Infof("Using NFQ %d", _etherFlags.NFQNumber)
 		etherInspector = &inspector.NFQInspector{
 			OrchestratorURL:  _etherFlags.OrchestratorURL,
 			EntityID:         _etherFlags.EntityID,


### PR DESCRIPTION
The address of ZMQ addr for communicating with hookswitch isn't used
in nfq mode. Printing it would be misleading.

/cc @AkihiroSuda I'm still not sure about the validity of this change, could you take a look?